### PR TITLE
Feat/send to pulsar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.6.2</common.version>
+        <common.version>0.6.1</common.version>
         <paho.version>1.2.0</paho.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.6.1</common.version>
+        <common.version>0.6.2</common.version>
         <paho.version>1.2.0</paho.version>
     </properties>
 

--- a/src/main/java/fi/hsl/pulsar/mqtt/Main.java
+++ b/src/main/java/fi/hsl/pulsar/mqtt/Main.java
@@ -56,7 +56,7 @@ public class Main {
             app = PulsarApplication.newInstance(config);
             connector = new MqttConnector(config, credentials.username, credentials.password);
 
-            MessageProcessor processor = new MessageProcessor(app);
+            MessageProcessor processor = new MessageProcessor(app, connector);
             //Let's subscribe to connector before connecting so we'll get all the events.
             connector.subscribe(processor);
 

--- a/src/main/java/fi/hsl/pulsar/mqtt/MessageProcessor.java
+++ b/src/main/java/fi/hsl/pulsar/mqtt/MessageProcessor.java
@@ -49,7 +49,6 @@ public class MessageProcessor implements IMqttMessageHandler {
             long now = System.currentTimeMillis();
             producer.newMessage()
                     .eventTime(now)
-                    .property(TransitdataProperties.KEY_SOURCE_MESSAGE_TIMESTAMP_MS, Long.toString(now))
                     .value(message.getPayload())
                     .sendAsync()
                     //.whenComplete() //Ack paho message here or close the app?

--- a/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
+++ b/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
@@ -94,6 +94,10 @@ public class MqttConnector implements MqttCallback {
     public void deliveryComplete(IMqttDeliveryToken token) {}
 
     public void close() {
+        if (mqttClient == null) {
+            log.warn("Cannot close mqtt connection since it's null");
+            return;
+        }
         try {
             log.info("Closing MqttConnector resources");
             //Paho doesn't close the connection threads unless we first disconnect and then force-close it.


### PR DESCRIPTION
send events to pulsar. Use async sending for performance reasons, approving that on errors we might lose some data.

on failure close the connections and the application.