### PR TITLE
Feature/50932 MQTT-Pulsar potential fix for Pulsar Timeouts

### DIFF
--- a/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
+++ b/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
@@ -113,7 +113,6 @@ public class MqttConnector implements MqttCallbackExtended {
         messageHandler.handleMessage(topic, message).whenComplete((res, err) -> {
             if (err != null) {
                 log.error("Failed to handle message, exiting application...");
-                close();
             } else if (manualAck) {
                 try {
                     mqttClient.messageArrivedComplete(message.getId(), message.getQos());

--- a/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
+++ b/src/main/java/fi/hsl/pulsar/mqtt/MqttConnector.java
@@ -112,7 +112,7 @@ public class MqttConnector implements MqttCallbackExtended {
     public void messageArrived(String topic, MqttMessage message) {
         messageHandler.handleMessage(topic, message).whenComplete((res, err) -> {
             if (err != null) {
-                log.error("Failed to handle message, exiting application...");
+                log.error("Failed to handle message due to error: ", err);
             } else if (manualAck) {
                 try {
                     mqttClient.messageArrivedComplete(message.getId(), message.getQos());


### PR DESCRIPTION
The issue that this PR is trying to fix is MQTT messages/data loss in case of a Pulsar timeout happening.
Currently, an MQTT message is acknowledged, only if the Pulsar sending is successful, otherwise, in case of any errors, the MQTT sessions is being forcibly terminated.
Pulsar timeouts can happen due to various reasons, one being throttling on Pulsar side.

Closing the MQTT session will not allow MQTT broker to retry the delivery of the MQTT message to the MQTT client/consumer. MQTT retry behavior is broker-driven, not client-driven.

For MQTT `QoS=1` or `QoS=2 ` (our case is `QoS=1`):

- The broker keeps the message until it receives an ACK
- If the client disconnects/crashes/does not ACK
- The broker will redeliver the message on:
  - reconnect
  - session resume `cleanSession=false` (which is our case)

Retry happens automatically on MQTT broker if and only if:
- `cleanSession=false`
- the message is not ACKed
- the client stays alive/connected or reconnects in case of forced close connections

Because of `close()` method that is called in case of an exception that is thrown in the middle of the message handling and subsequently, calling the following two methods:
```
mqttClient.disconnectForcibly()
mqttClient.close(true)
```
 - the MQTT broker is hard disconnected
 - the in-flight not yet acknowledged messages are dropped (so here is the root cause of the data loss)
 - no reconnection attempt is taking place
 - no session recovery is happening

In short, the reconsumption of the MQTT messages is handled by the MQTT broker, not by the MQTT client, but only if:
- the message is not ACKed
- the client session remains valid
- the client does not close itself

Currently, our code is not behaving like in the above-listed conditions.