### PR TITLE
Fix: Use Bash in start-application.sh

### DIFF
--- a/start-application.sh
+++ b/start-application.sh
@@ -1,7 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
-if [[ "${DEBUG_ENABLED}" = true ]]; then
-  java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -XX:InitialRAMPercentage=10.0 -XX:MaxRAMPercentage=95.0 -jar /usr/app/mqtt-pulsar-gateway.jar
-else
-  java -XX:InitialRAMPercentage=10.0 -XX:MaxRAMPercentage=95.0 -jar /usr/app/mqtt-pulsar-gateway.jar
+set -Eeuo pipefail
+
+JAVA_OPTS=(
+  -XX:InitialRAMPercentage=10.0
+  -XX:MaxRAMPercentage=95.0
+)
+
+if [[ "${DEBUG_ENABLED:-false}" == "true" ]]; then
+  JAVA_OPTS+=(
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  )
 fi
+
+exec java "${JAVA_OPTS[@]}" -jar /usr/app/mqtt-pulsar-gateway.jar


### PR DESCRIPTION
The original used bash features but had a shebang for Bourne shell. This
rewrite cleans it up a bit and uses bash. Bash is available in the
current image.
